### PR TITLE
Update KeyCodes.swift

### DIFF
--- a/Sources/SendKeysLib/KeyCodes.swift
+++ b/Sources/SendKeysLib/KeyCodes.swift
@@ -125,6 +125,10 @@ struct KeyCodes {
     static let keypad8: UInt16 = 0x5B
     static let keypad9: UInt16 = 0x5C
 
+    // JP-Keyboard
+    static let eisuu: UInt16 = 0x66 //英数
+    static let kana: UInt16 = 0x68 //かな
+
     struct KeyWithFlags {
         let keyCode: UInt16
         let flags: [CGEventFlags]
@@ -256,6 +260,10 @@ struct KeyCodes {
         "keypad7": KeyWithFlags(keypad7),
         "keypad8": KeyWithFlags(keypad8),
         "keypad9": KeyWithFlags(keypad9),
+
+        // JP-Keyboard
+        "eisuu": KeyWithFlags(eisuu), //英数
+        "kana": KeyWithFlags(kana), //かな
 
         // shift modifiers
         "A": KeyWithFlags(a, [.maskShift]),


### PR DESCRIPTION
Add two keys for Japanese(JP)Keyboard.

1. 英数 (EiSuu)
2. かな (KaNa)

![MK2A3J-mk](https://github.com/user-attachments/assets/1f27b60b-920b-4280-80ad-1ab4d8ba45fc)

Very useful, thanks.